### PR TITLE
Add playn locally to maven instructions

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -51,6 +51,15 @@ Once you have Maven installed, you'll also need [Git] installed so that you can 
 games to ensure that your setup is working. You can use a GUI git client or a command line client,
 it doesn't matter.
 
+### Locally install playn
+
+You might want to install a local copy of playn:
+```
+git clone git@github.com:playn/playn.git
+cd playn
+mvn clean install
+```
+
 ### Clone the samples
 
 Now that you're ready to go. Run the following (or do the equivalent in your GUI tool):


### PR DESCRIPTION
At the moment the correct version for playn is not in maven central. Installing the correct version from git enables the developer to run the samples.
