### PR TITLE
Update RoboVM info

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -560,6 +560,7 @@ running 4.0.3 or later.
 The iOS backend uses [RoboVM] to compile Java bytecode to ARM executables for deployment on iOS.
 RoboVM provides excellent emulation of many of the JRE APIs, which allows one to use many
 third-party Java libraries if they restrict their deployments to Java, Android and iOS.
+As of RoboVM 2.3.6, the minimum supported iOS target is iOS 7.
 
 RoboVM also provides Java-friendly translations of nearly all of the native iOS APIs, which allows
 games to implement iOS-specific functionality (like Game Center integration, camera access, etc.)
@@ -633,7 +634,7 @@ Overflow](http://stackoverflow.com/questions/tagged/playn).
 [RFuture]: http://threerings.github.io/react/apidocs/react/RFuture.html
 [React]: https://github.com/threerings/react
 [RenderTarget]: http://playn.github.io/docs/api/core/playn/core/RenderTarget.html
-[RoboVM]: http://www.robovm.com/
+[RoboVM]: http://robovm.mobidevelop.com/
 [RootLayer]: http://playn.github.io/docs/api/scene/playn/scene/RootLayer.html
 [SceneGame]: http://playn.github.io/docs/api/scene/playn/scene/SceneGame.html
 [Sound]: http://playn.github.io/docs/api/core/playn/core/Sound.html

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -215,6 +215,6 @@ comprise the game can be served from any web server you like.
 [Git]: http://git-scm.com/
 [Homebrew]: http://brew.sh/
 [Maven]: http://maven.apache.org/
-[RoboVM]: https://robovm.com/
+[RoboVM]: http://robovm.mobidevelop.com/
 [Xcode]: https://developer.apple.com/xcode/
 [iOS Hello World]: https://developer.apple.com/library/ios/samplecode/HelloWorld_iPhone/HelloWorld_iPhone.zip


### PR DESCRIPTION
 - Update RoboVM URL to point to mobidevelop's fork, since the original RoboVM is long gone
 - Document minimum iOS target (as of RoboVM 2.3.6, min is iOS 7)